### PR TITLE
feat: timeouts

### DIFF
--- a/components/runtime-models/src/discord/member.rs
+++ b/components/runtime-models/src/discord/member.rs
@@ -27,10 +27,8 @@ impl From<twilight_model::guild::PartialMember> for PartialMember {
                 .premium_since
                 .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             roles: v.roles.iter().map(ToString::to_string).collect(),
-            communication_disabled_until: match v.communication_disabled_until {
-                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
-                None => None,
-            },
+            communication_disabled_until: v.communication_disabled_until
+                .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
         }
     }
 }

--- a/components/runtime-models/src/discord/member.rs
+++ b/components/runtime-models/src/discord/member.rs
@@ -13,6 +13,7 @@ pub struct PartialMember {
     pub nick: Option<String>,
     pub premium_since: Option<NotBigU64>,
     pub roles: Vec<String>,
+    pub communication_disabled_until: Option<NotBigU64>,
 }
 
 impl From<twilight_model::guild::PartialMember> for PartialMember {
@@ -26,6 +27,10 @@ impl From<twilight_model::guild::PartialMember> for PartialMember {
                 .premium_since
                 .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             roles: v.roles.iter().map(ToString::to_string).collect(),
+            communication_disabled_until: match v.communication_disabled_until {
+                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
+                None => None,
+            },
         }
     }
 }

--- a/components/runtime-models/src/internal/member.rs
+++ b/components/runtime-models/src/internal/member.rs
@@ -63,10 +63,8 @@ impl From<twilight_model::guild::Member> for Member {
                 .premium_since
                 .map(|v| NotBigU64(v.as_micros() as u64 / 1000)),
             roles: v.roles.iter().map(ToString::to_string).collect(),
-            communication_disabled_until: match v.communication_disabled_until {
-                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
-                None => None,
-            },
+            communication_disabled_until: v.communication_disabled_until
+                .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             user: v.user.into(),
         }
     }
@@ -84,10 +82,8 @@ impl Member {
                 .premium_since()
                 .map(|v| NotBigU64(v.as_micros() as u64 / 1000)),
             roles: member.roles().iter().map(ToString::to_string).collect(),
-            communication_disabled_until: match member.communication_disabled_until() {
-                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
-                None => None,
-            },
+            communication_disabled_until: member.communication_disabled_until()
+                .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             pending: false,
         }
     }
@@ -100,10 +96,8 @@ impl Member {
                 .premium_since
                 .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             roles: partial.roles.iter().map(ToString::to_string).collect(),
-            communication_disabled_until: match partial.communication_disabled_until {
-                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
-                None => None,
-            },
+            communication_disabled_until: partial.communication_disabled_until
+                .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             user: partial.user.unwrap().into(),
             deaf: partial.deaf,
             mute: partial.mute,
@@ -127,10 +121,8 @@ impl From<twilight_model::gateway::payload::incoming::MemberUpdate> for Member {
                 .premium_since
                 .map(|v| NotBigU64(v.as_micros() as u64 / 1000)),
             roles: v.roles.iter().map(ToString::to_string).collect(),
-            communication_disabled_until: match v.communication_disabled_until {
-                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
-                None => None,
-            },
+            communication_disabled_until: v.communication_disabled_until
+                .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             user: v.user.into(),
         }
     }

--- a/components/runtime-models/src/internal/member.rs
+++ b/components/runtime-models/src/internal/member.rs
@@ -32,7 +32,8 @@ pub struct UpdateGuildMemberFields {
 
     #[ts(optional)]
     #[ts(type = "number|null")]
-    pub communication_disabled_until: Option<NotBigU64>,
+    #[serde(deserialize_with = "crate::deserialize_optional_field")]
+    pub communication_disabled_until: Option<Option<NotBigU64>>,
 }
 
 #[derive(Clone, Debug, Serialize, TS)]

--- a/components/runtime-models/src/internal/member.rs
+++ b/components/runtime-models/src/internal/member.rs
@@ -29,6 +29,10 @@ pub struct UpdateGuildMemberFields {
     #[ts(optional)]
     #[ts(type = "string[]")]
     pub roles: Option<Vec<Id<RoleMarker>>>,
+
+    #[ts(optional)]
+    #[ts(type = "number|null")]
+    pub communication_disabled_until: Option<NotBigU64>,
 }
 
 #[derive(Clone, Debug, Serialize, TS)]
@@ -43,6 +47,7 @@ pub struct Member {
     pub pending: bool,
     pub premium_since: Option<NotBigU64>,
     pub roles: Vec<String>,
+    pub communication_disabled_until: Option<NotBigU64>,
     pub user: User,
 }
 
@@ -58,6 +63,10 @@ impl From<twilight_model::guild::Member> for Member {
                 .premium_since
                 .map(|v| NotBigU64(v.as_micros() as u64 / 1000)),
             roles: v.roles.iter().map(ToString::to_string).collect(),
+            communication_disabled_until: match v.communication_disabled_until {
+                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
+                None => None,
+            },
             user: v.user.into(),
         }
     }
@@ -75,6 +84,10 @@ impl Member {
                 .premium_since()
                 .map(|v| NotBigU64(v.as_micros() as u64 / 1000)),
             roles: member.roles().iter().map(ToString::to_string).collect(),
+            communication_disabled_until: match member.communication_disabled_until() {
+                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
+                None => None,
+            },
             pending: false,
         }
     }
@@ -87,6 +100,10 @@ impl Member {
                 .premium_since
                 .map(|ts| NotBigU64(ts.as_micros() as u64 / 1000)),
             roles: partial.roles.iter().map(ToString::to_string).collect(),
+            communication_disabled_until: match partial.communication_disabled_until {
+                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
+                None => None,
+            },
             user: partial.user.unwrap().into(),
             deaf: partial.deaf,
             mute: partial.mute,

--- a/components/runtime-models/src/internal/member.rs
+++ b/components/runtime-models/src/internal/member.rs
@@ -127,6 +127,10 @@ impl From<twilight_model::gateway::payload::incoming::MemberUpdate> for Member {
                 .premium_since
                 .map(|v| NotBigU64(v.as_micros() as u64 / 1000)),
             roles: v.roles.iter().map(ToString::to_string).collect(),
+            communication_disabled_until: match v.communication_disabled_until {
+                Some(ts) => Some(NotBigU64(ts.as_micros() as u64 / 1000)),
+                None => None,
+            },
             user: v.user.into(),
         }
     }

--- a/components/runtime/src/extensions/discord.rs
+++ b/components/runtime/src/extensions/discord.rs
@@ -1025,6 +1025,10 @@ pub async fn op_discord_update_member(
         builder = builder.roles(roles);
     }
 
+    if let Some(ts) = &fields.communication_disabled_until {
+        builder = builder.communication_disabled_until(ts);
+    }
+
     let ret = builder
         .exec()
         .await

--- a/components/runtime/src/ts/discord/dapi.ts
+++ b/components/runtime/src/ts/discord/dapi.ts
@@ -255,7 +255,7 @@ export interface UpdateGuildMemberFields {
     /**
      * Updates the member's timeout duration, set to null to remove it.
      */
-    communicationDisabledUntil: Date | null;
+    communicationDisabledUntil: number | null;
 }
 
 export async function editMember(userId: string, fields: UpdateGuildMemberFields): Promise<Member> {
@@ -263,7 +263,7 @@ export async function editMember(userId: string, fields: UpdateGuildMemberFields
 }
 
 export async function setMemberTimeout(userId: string, time: Date | null): Promise<Member> {
-    return await editMember(userId, { communicationDisabledUntil: time });
+    return await editMember(userId, { communicationDisabledUntil: time ? time.getTime() : null });
 }
 
 export async function addMemberRole(userId: string, roleId: string): Promise<void> {

--- a/components/runtime/src/ts/discord/dapi.ts
+++ b/components/runtime/src/ts/discord/dapi.ts
@@ -251,10 +251,19 @@ export interface UpdateGuildMemberFields {
     nick?: string | null;
 
     roles?: string[];
+
+    /**
+     * Updates the member's timeout duration, set to null to remove it.
+     */
+    communicationDisabledUntil: Date | null;
 }
 
 export async function editMember(userId: string, fields: UpdateGuildMemberFields): Promise<Member> {
     return new Member(await OpWrappers.updateMember(userId, fields));
+}
+
+export async function setMemberTimeout(userId: string, time: Date | null): Promise<Member> {
+    return await editMember(userId, { communicationDisabledUntil: time });
 }
 
 export async function addMemberRole(userId: string, roleId: string): Promise<void> {

--- a/components/runtime/src/ts/discord/dapi.ts
+++ b/components/runtime/src/ts/discord/dapi.ts
@@ -255,7 +255,7 @@ export interface UpdateGuildMemberFields {
     /**
      * Updates the member's timeout duration, set to null to remove it.
      */
-    communicationDisabledUntil: number | null;
+    communicationDisabledUntil?: number | null;
 }
 
 export async function editMember(userId: string, fields: UpdateGuildMemberFields): Promise<Member> {

--- a/components/runtime/src/ts/discord/member.ts
+++ b/components/runtime/src/ts/discord/member.ts
@@ -10,6 +10,7 @@ export class Member {
     pending: boolean;
     premiumSince: number | null;
     roles: Array<string>;
+    communicationDisabledUntil: number | null;
     user: User;
 
     /**
@@ -23,6 +24,7 @@ export class Member {
         this.pending = json.pending;
         this.premiumSince = json.premiumSince;
         this.roles = json.roles;
+        this.communicationDisabledUntil = json.communicationDisabledUntil;
         this.user = new User(json.user);
     }
 

--- a/components/runtime/src/ts/generated/discord/PartialMember.ts
+++ b/components/runtime/src/ts/generated/discord/PartialMember.ts
@@ -5,4 +5,5 @@ export interface PartialMember {
   nick: string | null;
   premiumSince: number | null;
   roles: Array<string>;
+  communicationDisabledUntil: number | null;
 }

--- a/components/runtime/src/ts/generated/internal/Member.ts
+++ b/components/runtime/src/ts/generated/internal/Member.ts
@@ -8,5 +8,6 @@ export interface IMember {
   pending: boolean;
   premiumSince: number | null;
   roles: Array<string>;
+  communicationDisabledUntil: number | null;
   user: IUser;
 }


### PR DESCRIPTION
Implements timeouts, or `communicationDisabledUntil`, for Discord Member, plus a helper method so that people don't have to type out that really long property name.