### PR TITLE
fix: set default to provided value in SelectMenuOption#setdefault

### DIFF
--- a/components/runtime/src/ts/discord/components.ts
+++ b/components/runtime/src/ts/discord/components.ts
@@ -155,7 +155,7 @@ export class SelectMenuOption implements ISelectMenuOption {
     }
 
     setDefault(isDefault: boolean) {
-        this.default = this.default;
+        this.default = isDefault;
         return this;
     }
 


### PR DESCRIPTION
Previously, it would set the default to the \*current\* value.