### PR TITLE
build: Clean up workspace section using exclude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["components/*","cmd/*"]
-exclude = ["cmd/dbmigrations", "cmd/schedulewithworker"]
+exclude = ["cmd/dbmigrations", "cmd/schedulerwithworker"]
 
 [workspace.dependencies]
 serde = {version = "1.0", features=["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,6 @@
 [workspace]
-exclude = [
-	"components/vm-manager",
-	"components/common",
-	"components/runtime",
-	"components/tscompiler",
-	"cmd/dbmigrations",
-	"cmd/schedulewithworker",
-]
 members = ["components/*","cmd/*"]
+exclude = ["cmd/dbmigrations", "cmd/schedulewithworker"]
 
 [workspace.dependencies]
 serde = {version = "1.0", features=["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,13 @@
 [workspace]
-members = [
-    "components/vmthread",
-    "components/vm",
-    "components/isolatecell",
-    "components/stores",
-    "components/discordoauthwrapper",
-    "components/simpleproto",
-    "components/botrpc",
-    "components/dbrokerapi",
-    "components/axum-metrics-layer",
-    # "components/vm-manager",
-    "components/guild-logger",
-    "components/runtime-models",
-    "components/scheduler-worker-rpc",
-    "cmd/webapi",
-    "cmd/prepare-integration-tests",
-    "cmd/discordbroker",
-    "cmd/scheduler",
-    "cmd/vmworker",
-    "cmd/dbserver",
-    "cmd/jobs",
-    "cmd/blcmd",
+exclude = [
+	"components/vm-manager",
+	"components/common",
+	"components/runtime",
+	"components/tscompiler",
+	"cmd/dbmigrations",
+	"cmd/schedulewithworker",
 ]
+members = ["components/*","cmd/*"]
 
 [workspace.dependencies]
 serde = {version = "1.0", features=["derive"]}


### PR DESCRIPTION
Cleans up crate member inclusion in the `workspace` section of the `Cargo.toml` file, by explicitly excluding crates from the blanket selections of `components/*` and `cmd/*`.